### PR TITLE
Add multi-NAICS support with chip input, validation, API update, and sidebar display

### DIFF
--- a/src/components/layout/WizardShell.tsx
+++ b/src/components/layout/WizardShell.tsx
@@ -1,18 +1,25 @@
-import { Outlet, Link, useLocation } from 'react-router-dom';
-import { X, Check } from 'lucide-react';
-import { useWizard } from '@/context/WizardContext';
+import { Outlet, Link, useLocation } from "react-router-dom";
+import { X, Check } from "lucide-react";
+import { useWizard } from "@/context/WizardContext";
+import { NaicsInline } from "@/components/ui/naics-inline";
 
 const steps = [
-  { number: 1, label: 'Program', path: '/app/step-1' },
-  { number: 2, label: 'Logo', path: '/app/step-2' },
-  { number: 3, label: 'Industry', path: '/app/step-3' },
-  { number: 4, label: 'Preview', path: '/app/step-4' },
-  { number: 5, label: 'Pay', path: '/app/step-5' },
+  { number: 1, label: "Program", path: "/app/step-1" },
+  { number: 2, label: "Logo", path: "/app/step-2" },
+  { number: 3, label: "Industry", path: "/app/step-3" },
+  { number: 4, label: "Preview", path: "/app/step-4" },
+  { number: 5, label: "Pay", path: "/app/step-5" },
 ];
 
 export const WizardShell = () => {
   const location = useLocation();
-  const { selectedPlan, hasIndustryAddOn, province, naicsCode, getTotalPrice } = useWizard();
+  const {
+    selectedPlan,
+    hasIndustryAddOn,
+    province,
+    naicsCodes,
+    getTotalPrice,
+  } = useWizard();
 
   const getCurrentStep = () => {
     const match = location.pathname.match(/step-(\d)/);
@@ -22,9 +29,9 @@ export const WizardShell = () => {
   const currentStep = getCurrentStep();
 
   const getStepStatus = (stepNumber: number) => {
-    if (stepNumber < currentStep) return 'complete';
-    if (stepNumber === currentStep) return 'active';
-    return 'inactive';
+    if (stepNumber < currentStep) return "complete";
+    if (stepNumber === currentStep) return "active";
+    return "inactive";
   };
 
   return (
@@ -54,19 +61,21 @@ export const WizardShell = () => {
                 <Link
                   to={step.path}
                   className={`flex items-center gap-2 ${
-                    getStepStatus(step.number) === 'inactive' ? 'pointer-events-none opacity-50' : ''
+                    getStepStatus(step.number) === "inactive"
+                      ? "pointer-events-none opacity-50"
+                      : ""
                   }`}
                 >
                   <div
                     className={`step-indicator ${
-                      getStepStatus(step.number) === 'active'
-                        ? 'step-indicator-active'
-                        : getStepStatus(step.number) === 'complete'
-                        ? 'step-indicator-complete'
-                        : 'step-indicator-inactive'
+                      getStepStatus(step.number) === "active"
+                        ? "step-indicator-active"
+                        : getStepStatus(step.number) === "complete"
+                          ? "step-indicator-complete"
+                          : "step-indicator-inactive"
                     }`}
                   >
-                    {getStepStatus(step.number) === 'complete' ? (
+                    {getStepStatus(step.number) === "complete" ? (
                       <Check size={16} />
                     ) : (
                       step.number
@@ -74,9 +83,9 @@ export const WizardShell = () => {
                   </div>
                   <span
                     className={`hidden sm:block text-sm font-medium ${
-                      getStepStatus(step.number) === 'active'
-                        ? 'text-wizard-text'
-                        : 'text-wizard-text-muted'
+                      getStepStatus(step.number) === "active"
+                        ? "text-wizard-text"
+                        : "text-wizard-text-muted"
                     }`}
                   >
                     {step.label}
@@ -102,32 +111,46 @@ export const WizardShell = () => {
           {/* Summary Panel */}
           <div className="lg:col-span-1">
             <div className="bg-white rounded-2xl border border-wizard-border shadow-lg shadow-black/5 p-6 sticky top-24">
-              <h3 className="font-heading text-xl text-wizard-text mb-6">Order Summary</h3>
-              
+              <h3 className="font-heading text-xl text-wizard-text mb-6">
+                Order Summary
+              </h3>
+
               <div className="space-y-4">
                 <div className="flex justify-between py-3 border-b border-wizard-border">
-                  <span className="text-wizard-text-muted text-sm">Selected Plan</span>
+                  <span className="text-wizard-text-muted text-sm">
+                    Selected Plan
+                  </span>
                   <span className="text-wizard-text font-medium">
-                    {selectedPlan?.name || '—'}
+                    {selectedPlan?.name || "—"}
                   </span>
                 </div>
 
                 {hasIndustryAddOn && (
                   <div className="flex justify-between py-3 border-b border-wizard-border">
-                    <span className="text-wizard-text-muted text-sm">Add-On</span>
-                    <span className="text-wizard-text font-medium">Industry-Specific</span>
+                    <span className="text-wizard-text-muted text-sm">
+                      Add-On
+                    </span>
+                    <span className="text-wizard-text font-medium">
+                      Industry-Specific
+                    </span>
                   </div>
                 )}
-                
+
                 <div className="flex justify-between py-3 border-b border-wizard-border">
-                  <span className="text-wizard-text-muted text-sm">Province</span>
-                  <span className="text-wizard-text font-medium">{province}</span>
-                </div>
-                
-                <div className="flex justify-between py-3 border-b border-wizard-border">
-                  <span className="text-wizard-text-muted text-sm">NAICS Code</span>
+                  <span className="text-wizard-text-muted text-sm">
+                    Province
+                  </span>
                   <span className="text-wizard-text font-medium">
-                    {naicsCode || '—'}
+                    {province}
+                  </span>
+                </div>
+
+                <div className="flex justify-between py-3 border-b border-wizard-border gap-4">
+                  <span className="text-wizard-text-muted text-sm">
+                    NAICS Codes
+                  </span>
+                  <span className="text-wizard-text font-medium text-right">
+                    <NaicsInline codes={naicsCodes} maxInline={2} />
                   </span>
                 </div>
 
@@ -135,7 +158,9 @@ export const WizardShell = () => {
                   <div className="flex justify-between items-center">
                     <span className="text-wizard-text font-medium">Total</span>
                     <span className="font-heading text-2xl text-wizard-text">
-                      {selectedPlan ? `$${getTotalPrice().toFixed(2)} CAD` : '—'}
+                      {selectedPlan
+                        ? `$${getTotalPrice().toFixed(2)} CAD`
+                        : "—"}
                     </span>
                   </div>
                 </div>

--- a/src/components/ui/naics-chip-input.tsx
+++ b/src/components/ui/naics-chip-input.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from "react";
+
+const NAICS_REGEX = /^\d{6}$/;
+
+function splitTokens(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/g)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+export function NaicsChipInput(props: {
+  value: string[];
+  onChange: (next: string[]) => void;
+  max?: number;
+  error?: string;
+  onErrorChange?: (msg: string) => void;
+}) {
+  const { value, onChange, max = 10, error, onErrorChange } = props;
+  const [text, setText] = useState("");
+
+  const cleanValue = useMemo(
+    () => (value ?? []).map((v) => v.trim()).filter(Boolean),
+    [value],
+  );
+
+  const commit = (raw: string) => {
+    const tokens = splitTokens(raw);
+    if (tokens.length === 0) return;
+
+    const existing = new Set(cleanValue);
+    const invalid: string[] = [];
+    const duplicates: string[] = [];
+    const accepted: string[] = [];
+
+    for (const t of tokens) {
+      if (!NAICS_REGEX.test(t)) invalid.push(t);
+      else if (existing.has(t)) duplicates.push(t);
+      else {
+        accepted.push(t);
+        existing.add(t);
+      }
+    }
+
+    const spaceLeft = Math.max(0, max - cleanValue.length);
+    const toAdd = accepted.slice(0, spaceLeft);
+    const overflow = accepted.slice(spaceLeft);
+
+    const next = [...cleanValue, ...toAdd];
+    onChange(next);
+
+    const msgs: string[] = [];
+    if (invalid.length) msgs.push(`Invalid: ${invalid.join(", ")}`);
+    if (duplicates.length)
+      msgs.push(`Duplicate ignored: ${duplicates.join(", ")}`);
+    if (overflow.length)
+      msgs.push(`Max ${max} reached; ignored: ${overflow.join(", ")}`);
+
+    onErrorChange?.(msgs.length ? msgs.join(" • ") : "");
+  };
+
+  const removeAt = (idx: number) => {
+    const next = cleanValue.filter((_, i) => i !== idx);
+    onChange(next);
+    onErrorChange?.("");
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border border-wizard-border bg-white p-2">
+        {cleanValue.map((chip, idx) => (
+          <span
+            key={`${chip}-${idx}`}
+            className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm text-wizard-text"
+          >
+            {chip}
+            <button
+              type="button"
+              onClick={() => removeAt(idx)}
+              className="rounded-full px-1 hover:bg-wizard-bg"
+              aria-label={`Remove NAICS ${chip}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={
+            cleanValue.length >= max
+              ? `Max ${max} codes`
+              : "Type code and press Enter"
+          }
+          disabled={cleanValue.length >= max}
+          className="min-w-[180px] flex-1 bg-transparent p-2 text-sm text-gray-900 outline-none placeholder:text-gray-500"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit(text);
+              setText("");
+            }
+            if (
+              e.key === "Backspace" &&
+              text.length === 0 &&
+              cleanValue.length > 0
+            ) {
+              removeAt(cleanValue.length - 1);
+            }
+          }}
+          onPaste={(e) => {
+            const paste = e.clipboardData.getData("text");
+            if (!paste) return;
+            if (/[,\s]/.test(paste)) {
+              e.preventDefault();
+              commit(paste);
+              setText("");
+            }
+          }}
+        />
+      </div>
+
+      {error ? (
+        <p className="text-error text-sm mt-1">{error}</p>
+      ) : (
+        <p className="text-wizard-text-muted text-xs mt-1">
+          Add 6-digit NAICS codes. Paste comma/space separated. Max {max}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/naics-inline.tsx
+++ b/src/components/ui/naics-inline.tsx
@@ -1,0 +1,29 @@
+type Props = {
+  codes: string[];
+  maxInline?: number;
+};
+
+export function NaicsInline({ codes, maxInline = 2 }: Props) {
+  const clean = (codes ?? []).map((c) => c.trim()).filter(Boolean);
+  if (clean.length === 0)
+    return <span className="text-wizard-text-muted">—</span>;
+
+  const inline = clean.slice(0, maxInline);
+  const overflow = clean.length - inline.length;
+  const all = clean.join(", ");
+
+  return (
+    <span className="inline-flex items-center gap-1 flex-wrap">
+      <span>{inline.join(", ")}</span>
+      {overflow > 0 ? (
+        <span
+          className="cursor-help rounded-sm px-1 text-sm text-wizard-text-muted underline decoration-dotted"
+          title={all}
+          aria-label={`NAICS codes: ${all}`}
+        >
+          +{overflow} more
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/context/WizardContext.tsx
+++ b/src/context/WizardContext.tsx
@@ -8,7 +8,7 @@ interface WizardState {
   logoFile: File | null;
   logoPreview: string | null;
   province: string;
-  naicsCode: string;
+  naicsCodes: string[];
   businessDescription: string;
   companyName: string;
   userEmail: string;
@@ -28,7 +28,7 @@ interface WizardContextType extends WizardState {
   setLogoFile: (file: File | null) => void;
   setLogoPreview: (preview: string | null) => void;
   setProvince: (province: string) => void;
-  setNaicsCode: (code: string) => void;
+  setNaicsCodes: (codes: string[]) => void;
   setBusinessDescription: (description: string) => void;
   setCompanyName: (name: string) => void;
   setUserEmail: (email: string) => void;
@@ -53,7 +53,7 @@ const initialState: WizardState = {
   logoFile: null,
   logoPreview: null,
   province: "Ontario",
-  naicsCode: "",
+  naicsCodes: [],
   businessDescription: "",
   companyName: "",
   userEmail: "",
@@ -107,8 +107,8 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({
     setState((prev) => ({ ...prev, province }));
   };
 
-  const setNaicsCode = (code: string) => {
-    setState((prev) => ({ ...prev, naicsCode: code }));
+  const setNaicsCodes = (codes: string[]) => {
+    setState((prev) => ({ ...prev, naicsCodes: codes }));
   };
 
   const setBusinessDescription = (description: string) => {
@@ -182,7 +182,7 @@ export const WizardProvider: React.FC<{ children: ReactNode }> = ({
         setLogoFile,
         setLogoPreview,
         setProvince,
-        setNaicsCode,
+        setNaicsCodes,
         setBusinessDescription,
         setCompanyName,
         setUserEmail,

--- a/src/pages/wizard/Step3.tsx
+++ b/src/pages/wizard/Step3.tsx
@@ -4,7 +4,6 @@ import { useWizard } from "@/context/WizardContext";
 import { provinces, getTOCForPlan } from "@/data/mockData";
 import { Loader2, FileText, Shield, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -16,6 +15,7 @@ import { motion } from "framer-motion";
 import { toast } from "sonner";
 import { api, ApiError } from "@/services/api";
 import { provinceNameToCode } from "@/lib/provinceMapping";
+import { NaicsChipInput } from "@/components/ui/naics-chip-input";
 
 const Step3 = () => {
   const navigate = useNavigate();
@@ -23,7 +23,7 @@ const Step3 = () => {
     selectedPlan,
     hasIndustryAddOn,
     province,
-    naicsCode,
+    naicsCodes,
     businessDescription,
     companyName,
     logoFile,
@@ -31,11 +31,12 @@ const Step3 = () => {
     orderId,
     documentId,
     setProvince,
-    setNaicsCode,
+    setNaicsCodes,
     setBusinessDescription,
     setTocGenerated,
     setDocumentId,
   } = useWizard();
+
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState("");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -69,14 +70,22 @@ const Step3 = () => {
     };
   }, [tocGenerated, documentId, previewUrl]);
 
-  const validateNaicsCode = (code: string) => {
-    if (!code) return "NAICS code is required";
-    if (!/^\d{2,6}$/.test(code)) return "NAICS code must be 2-6 digits";
+  const validateNaicsCodes = (codes: string[]) => {
+    if (!codes || codes.length === 0) {
+      return "At least one NAICS code is required";
+    }
+
+    for (const code of codes) {
+      if (!/^\d{6}$/.test(code)) {
+        return "Each NAICS code must be exactly 6 digits";
+      }
+    }
+
     return "";
   };
 
   const handleGenerateTOC = async () => {
-    const validationError = validateNaicsCode(naicsCode);
+    const validationError = validateNaicsCodes(naicsCodes);
     if (validationError) {
       setError(validationError);
       return;
@@ -103,7 +112,7 @@ const Step3 = () => {
       await api.updateCompanyDetails(orderId, {
         company_name: companyName,
         province: provinceCode,
-        naics_codes: naicsCode,
+        naics_codes: naicsCodes,
         logo: logoFile || undefined,
         business_description:
           businessDescription && businessDescription.trim() !== ""
@@ -137,6 +146,8 @@ const Step3 = () => {
   const fullPlanName = hasIndustryAddOn
     ? `${planName} + Industry-Specific`
     : planName;
+
+  const naicsDisplay = naicsCodes.length > 0 ? naicsCodes.join(", ") : "—";
 
   return (
     <div className="space-y-8">
@@ -176,27 +187,17 @@ const Step3 = () => {
 
           <div>
             <label className="block text-sm font-medium text-wizard-text mb-2">
-              NAICS Industry Code
+              NAICS Industry Codes
             </label>
-            <Input
-              type="text"
-              placeholder="e.g., 23 (Construction) or 31 (Manufacturing)"
-              value={naicsCode}
-              onChange={(e) => {
-                setNaicsCode(e.target.value);
+            <NaicsChipInput
+              value={naicsCodes}
+              onChange={(codes) => {
+                setNaicsCodes(codes);
                 setError("");
               }}
-              className={`h-12 bg-white border-wizard-border text-wizard-text placeholder:text-wizard-text-muted ${
-                error ? "border-error focus:border-error focus:ring-error" : ""
-              }`}
+              error={error}
+              onErrorChange={setError}
             />
-            {error ? (
-              <p className="text-error text-sm mt-1">{error}</p>
-            ) : (
-              <p className="text-wizard-text-muted text-xs mt-1">
-                Enter a 2-6 digit NAICS code
-              </p>
-            )}
           </div>
         </div>
 
@@ -235,7 +236,7 @@ const Step3 = () => {
 
         <Button
           onClick={handleGenerateTOC}
-          disabled={isGenerating || !naicsCode}
+          disabled={isGenerating || naicsCodes.length === 0}
           variant="outline"
           className="bg-wizard-text text-white border-wizard-text hover:bg-wizard-text/90 hover:text-white"
         >
@@ -268,14 +269,14 @@ const Step3 = () => {
             <div className="bg-gradient-to-r from-primary/10 to-primary/5 px-6 md:px-8 py-6 border-b border-wizard-border">
               <div className="flex items-center gap-4">
                 <div className="w-14 h-14 md:w-16 md:h-16 rounded-xl bg-primary/10 flex items-center justify-center shrink-0">
-                  <Shield className="w-7 h-7 md:w-8 md:h-8 text-primary" />
+                  <Shield className="w-7 h-7 md:h-8 md:w-8 text-primary" />
                 </div>
                 <div>
                   <h3 className="font-heading text-lg md:text-xl font-semibold text-wizard-text">
                     Health & Safety Manual
                   </h3>
                   <p className="text-sm text-wizard-text-muted">
-                    {fullPlanName} Edition • {province} • NAICS {naicsCode}
+                    {fullPlanName} Edition • {province} • NAICS {naicsDisplay}
                   </p>
                 </div>
               </div>
@@ -334,7 +335,7 @@ const Step3 = () => {
                 <span>Fully editable DOCX format</span>
               </div>
               <div className="text-sm text-wizard-text-muted">
-                Generated for NAICS {naicsCode}
+                Generated for NAICS {naicsDisplay}
               </div>
             </div>
           </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,7 +32,7 @@ interface CreateOrderResponse {
 interface UpdateCompanyDetailsRequest {
   company_name: string;
   province: string;
-  naics_codes: string;
+  naics_codes: string[];
   logo?: File;
   business_description?: string;
 }
@@ -292,7 +292,10 @@ export const api = {
     const formData = new FormData();
     formData.append("company_name", data.company_name);
     formData.append("province", data.province);
-    formData.append("naics_codes", data.naics_codes);
+
+    data.naics_codes.forEach((code) => {
+      formData.append("naics_codes", code);
+    });
 
     if (data.logo) {
       formData.append("logo", data.logo);


### PR DESCRIPTION
Replaced the single NAICS input in Step 3 with a chip-based NaicsChipInput to support multiple codes. Updated WizardContext to use a naicsCodes array and ensured values persist across navigation. 
Modified API integration to send NAICS codes as repeated naics_codes fields. Enforced validation to require at least one code and ensure each code is exactly 6 digits (aligned with backend). 
Updated the sidebar using NaicsInline to display the first two codes with a “+N more” indicator.

<img width="1912" height="972" alt="Step-3 NAICS - multiple codes chips check - output" src="https://github.com/user-attachments/assets/1476a5c7-86e1-4914-92da-5d6b99f88d5d" />

<img width="1917" height="968" alt="step-3 NAICS invalid input check - invalid code range" src="https://github.com/user-attachments/assets/d308c12d-35e0-4909-b14f-e91910ab91a0" />

<img width="1368" height="813" alt="step-3 NAICS invalid input check - invalid code range - output" src="https://github.com/user-attachments/assets/18c1d98a-8b45-4de8-9498-d3142239267d" />

<img width="1912" height="968" alt="step-3 Active wizard shell - N more codes" src="https://github.com/user-attachments/assets/96810e23-3dfa-4ce0-8acd-ca60d23a9bd9" />

<img width="1915" height="968" alt="Step-3 Document generated - 6 digits NAICS code" src="https://github.com/user-attachments/assets/75954822-8e05-46ef-9ce3-4b91c0615f33" />

<img width="1918" height="968" alt="step-3 Document generated - company details payload - 6 digits NAICS code" src="https://github.com/user-attachments/assets/b01cb8b3-7287-43a7-90da-cacb6982d3a6" />

<img width="1916" height="971" alt="Step-3 NAICS payload - array type - single code" src="https://github.com/user-attachments/assets/66a99a2c-cf53-4325-af25-f42b5f6475ea" />

<img width="1918" height="971" alt="Step-3 NAICS payload - array type - multiple codes" src="https://github.com/user-attachments/assets/533efc0b-1b71-4be8-b91d-1852f6d951bb" />

